### PR TITLE
building for scala 2.11, update to latest aws-sdk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,3 @@
-// sbt-dependency-graph settings
-net.virtualvoid.sbt.graph.Plugin.graphSettings
-
 // sbt-release settings
 releaseSettings
 
@@ -12,15 +9,16 @@ description := "Opinionated, idiomatic Scala library for Amazon Web Services."
 
 homepage := Some(url("https://github.com/cloudify/scalazon"))
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.11.4"
 
 licenses += ( "MIT" -> url("http://opensource.org/licenses/MIT") )
 
 unmanagedSourceDirectories in Compile += baseDirectory.value / "examples"
 
+
 libraryDependencies ++= Seq(
-  "com.amazonaws"       % "aws-java-sdk"    % "1.8.9",
-  "org.scalatest"      %% "scalatest"       % "2.0"     % "test",
+  "com.amazonaws" % "aws-java-sdk" % "1.9.8",
+  "org.scalatest" % "scalatest_2.11" % "2.2.1" % "test",
   "org.mockito"         % "mockito-all"     % "1.9.0"   % "test"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,5 +8,3 @@ resolvers += Resolver.url(
         Resolver.ivyStylePatterns)
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")


### PR DESCRIPTION
Hi,
would be nice to upgrade Scalazon for Scala 2.11.
To get everything to compile i had to remove the sbt-dependency-graph plugin as there is no
binary for 2.11 yet. I also upgraded the aws-java-sdk to the latest version.
The unit test passes. You like to merge back my changes? If latest=greatest is not an option, an alternative would be to setup sbt for cross-building.

Best regards,
Jan
