### PR TITLE
Support PutRecords

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ licenses += ( "MIT" -> url("http://opensource.org/licenses/MIT") )
 unmanagedSourceDirectories in Compile += baseDirectory.value / "examples"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws"       % "aws-java-sdk"    % "1.9.8",
+  "com.amazonaws"       % "aws-java-sdk"    % "1.9.23",
   "org.mockito"         % "mockito-all"     % "1.10.8"   % "test"
 )
 

--- a/src/main/scala/io/github/cloudify/scala/aws/kinesis/Client.scala
+++ b/src/main/scala/io/github/cloudify/scala/aws/kinesis/Client.scala
@@ -133,11 +133,11 @@ class ClientImpl(val kinesisClient: AmazonKinesis) extends Client {
     val putRecordsRequest = new model.PutRecordsRequest()
     putRecordsRequest.setStreamName(r.streamDef.name)
 
-    val putRecordsRequestEntryList = r.data.map {record =>
+    val putRecordsRequestEntryList = r.records.map {record =>
       val putRecordsRequestEntry = new model.PutRecordsRequestEntry
-      putRecordsRequestEntry.setPartitionKey(r.partitionKey)
-      r.explicitHashKey.foreach { k => putRecordsRequestEntry.setExplicitHashKey(k) }
-      putRecordsRequestEntry.setData(record)
+      putRecordsRequestEntry.setPartitionKey(record.partitionKey)
+      record.explicitHashKey.foreach { k => putRecordsRequestEntry.setExplicitHashKey(k) }
+      putRecordsRequestEntry.setData(record.data)
       putRecordsRequestEntry
     }
 

--- a/src/main/scala/io/github/cloudify/scala/aws/kinesis/StreamDsl.scala
+++ b/src/main/scala/io/github/cloudify/scala/aws/kinesis/StreamDsl.scala
@@ -87,6 +87,11 @@ trait StreamDsl {
    */
   def put(data: ByteBuffer, partitionKey: String): Requests.PutRecord
 
+  /**
+   * Puts more than one record in the stream
+   */
+  def multiPut(data: List[ByteBuffer], partitionKey: String): Requests.PutRecords
+
 }
 
 trait StreamDescriptionDsl {
@@ -150,9 +155,19 @@ trait PutRecordDsl[A] {
   def withoutExclusiveMinimumSequenceNumber: A
 }
 
+trait PutRecordsDsl[A] {
+  def withExclusiveMinimumSequenceNumber(seqNumber: String): A
+  def withoutExclusiveMinimumSequenceNumber: A
+}
+
 trait PutResultDsl {
   def shardId: String
   def sequenceNumber: String
+}
+
+trait PutsResultDsl {
+  def shardIds: List[String]
+  def sequenceNumber: List[String]
 }
 
 object Definitions {
@@ -171,6 +186,8 @@ object Definitions {
     def waitActive: Requests.WaitStreamActive = Requests.WaitStreamActive(this)
 
     def put(data: ByteBuffer, partitionKey: String): Requests.PutRecord = Requests.PutRecord(this, data, partitionKey)
+
+    def multiPut(data: List[ByteBuffer], partitionKey: String): Requests.PutRecords = Requests.PutRecords(this, data, partitionKey)
 
   }
 
@@ -214,6 +231,11 @@ object Definitions {
     def sequenceNumber: String = result.getSequenceNumber
   }
 
+  case class PutsResult(result: model.PutRecordsResult) extends PutsResultDsl {
+    def shardIds: List[String] = result.getRecords.asScala.toList.map(_.getShardId)
+    def sequenceNumber: List[String] = result.getRecords.asScala.toList.map(_.getSequenceNumber)
+  }
+
 }
 
 object Requests {
@@ -243,6 +265,13 @@ object Requests {
   case class ListStreamShards(streamDef: Definitions.Stream)
 
   case class PutRecord(streamDef: Definitions.Stream, data: ByteBuffer, partitionKey: String, minSeqNumber: Option[String] = None, seqNumberForOrdering: Option[String] = None, explicitHashKey: Option[String] = None) extends PutRecordDsl[PutRecord] {
+    def withExclusiveMinimumSequenceNumber(seqNumber: String) = this.copy(minSeqNumber = Some(seqNumber))
+    def withoutExclusiveMinimumSequenceNumber = this.copy(minSeqNumber = None)
+    def withSequenceNumberForOrdering(seqNumber: String) = this.copy(seqNumberForOrdering = Some(seqNumber))
+    def withExplicitHashKey(hashKey: String) = this.copy(explicitHashKey = Some(hashKey))
+  }
+
+  case class PutRecords(streamDef: Definitions.Stream, data: List[ByteBuffer], partitionKey: String,  minSeqNumber: Option[String] = None, seqNumberForOrdering: Option[String] = None, explicitHashKey: Option[String] = None) extends PutRecordsDsl[PutRecords] {
     def withExclusiveMinimumSequenceNumber(seqNumber: String) = this.copy(minSeqNumber = Some(seqNumber))
     def withoutExclusiveMinimumSequenceNumber = this.copy(minSeqNumber = None)
     def withSequenceNumberForOrdering(seqNumber: String) = this.copy(seqNumberForOrdering = Some(seqNumber))


### PR DESCRIPTION
This adds the ability to send multiple records at once like this:

``` scala
val putData = for {
  p <- myStream.multiPut(List(record1 -> partitionKey1, record2 -> partitionKey2))
} yield p
```

Happy to make any improvements you suggest!
