### PR TITLE
bump aws sdk dep to 1.11.86 and limit to kinesis for lighter build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ licenses += ( "MIT" -> url("http://opensource.org/licenses/MIT") )
 unmanagedSourceDirectories in Compile += baseDirectory.value / "examples"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws"       % "aws-java-sdk"    % "1.9.23",
+  "com.amazonaws"       % "aws-java-sdk-kinesis"    % "1.11.86",
   "org.mockito"         % "mockito-all"     % "1.10.8"   % "test"
 )
 


### PR DESCRIPTION
Restricting dependency to only components actually used (kinesis) for lighter build.