### PR TITLE
Adding ContainerCredentialsProvider as IAM option

### DIFF
--- a/src/main/scala/io/github/cloudify/scala/aws/auth/CredentialsProvider.scala
+++ b/src/main/scala/io/github/cloudify/scala/aws/auth/CredentialsProvider.scala
@@ -36,6 +36,11 @@ object CredentialsProvider {
   lazy val InstanceProfile = new InstanceProfileCredentialsProvider()
 
   /**
+   * Provides an instance of the `Container` provider
+   */
+  lazy val Container = new ContainerCredentialsProvider()
+
+  /**
    * Provides an instance of the default `ClasspathPropertiesFileCredentialsProvider` provider.
    */
   lazy val DefaultClasspathPropertiesFile = new ClasspathPropertiesFileCredentialsProvider()


### PR DESCRIPTION
If using on AWS ECS, you'd want to use an IAM role specific to the container task definition, not the EC2 instance it's running on.

To do this you need access to the ContainerCredentialsProvider, documented here: http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html