### PR TITLE
Updating aws SDK and restricting to necessary packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,9 @@ licenses += ( "MIT" -> url("http://opensource.org/licenses/MIT") )
 unmanagedSourceDirectories in Compile += baseDirectory.value / "examples"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws"       % "aws-java-sdk"    % "1.9.23",
-  "org.mockito"         % "mockito-all"     % "1.10.8"   % "test"
+  "com.amazonaws"       % "aws-java-sdk-kinesis"  % "1.11.128",
+  "com.amazonaws"       % "aws-java-sdk-core"     % "1.11.128",
+  "org.mockito"         % "mockito-all"           % "1.10.8"   % "test"
 )
 
 def scalatestDependency(scalaVersion: String) = scalaVersion match {

--- a/src/main/scala/io/github/cloudify/scala/aws/auth/CredentialsProvider.scala
+++ b/src/main/scala/io/github/cloudify/scala/aws/auth/CredentialsProvider.scala
@@ -33,7 +33,7 @@ object CredentialsProvider {
   /**
    * Provides an instance of the `InstanceProfile` provider
    */
-  lazy val InstanceProfile = new InstanceProfileCredentialsProvider()
+  lazy val InstanceProfile = new InstanceProfileCredentialsProvider(false)
 
   /**
    * Provides an instance of the `Container` provider

--- a/src/main/scala/io/github/cloudify/scala/aws/auth/CredentialsProvider.scala
+++ b/src/main/scala/io/github/cloudify/scala/aws/auth/CredentialsProvider.scala
@@ -36,6 +36,11 @@ object CredentialsProvider {
   lazy val InstanceProfile = new InstanceProfileCredentialsProvider()
 
   /**
+   * Provides an instance of the `Container` provider
+   */
+  lazy val Container = new ContainerCredentialsProvider()
+
+  /**
    * Provides an instance of the default `ClasspathPropertiesFileCredentialsProvider` provider.
    */
   lazy val DefaultClasspathPropertiesFile = new ClasspathPropertiesFileCredentialsProvider()


### PR DESCRIPTION
Adding ContainerCredentialsProvider as IAM option.

This requires the latest version of the AWS SDK, so that dependency has been updated, and it's also been restricted to only the necessary components to cut down on dependencies/package size.